### PR TITLE
Turned out split-views was a very bad idea

### DIFF
--- a/types/direct/encoder.d.ts
+++ b/types/direct/encoder.d.ts
@@ -1,6 +1,5 @@
 export function encode(value: any): number[];
-export function encoder({ byteOffset, splitViews }?: {
+export function encoder({ byteOffset }?: {
     byteOffset?: number;
-    splitViews?: boolean;
 }): (value: any, buffer: SharedArrayBuffer) => number;
 export type Cache = Map<number, number[]>;


### PR DESCRIPTION
I am creating a PR for history sake but basically the *split-views* in coincident demonstrated to be 3 times slower than the push based solution. It is possible that the code gets JIT'd in a special way that *split-views* breaks but I think, after all, it's not worth it.

The previous buffer approach that was ad-hoc could come back in the future but for the time being I think we're good with the current general-purpose approach.