### PR TITLE
A different approach to buffered encoding

### DIFF
--- a/src/direct/array.js
+++ b/src/direct/array.js
@@ -1,0 +1,62 @@
+export default class BufferedArray {
+  /**
+   * @param {BufferedArray} self
+   * @param {Uint8Array} value
+   */
+  static push(self, value) {
+    self.c();
+    self.v.set(value, self.g(value.length));
+  }
+
+  /**
+   * @param {SharedArrayBuffer} buffer
+   * @param {number} offset
+   */
+  constructor(buffer, offset) {
+    /** @type {number[]} */
+    const output = [];
+
+    /** @private length */
+    this.l = 0;
+
+    /** @private view */
+    this.v = new Uint8Array(buffer, offset);
+
+    /** @private output */
+    this.o = output;
+
+    /** @type {typeof Array.prototype.push} */
+    this.push = output.push.bind(output);
+  }
+
+  get length() {
+    this.c();
+    return this.l;
+  }
+
+  /**
+   * commit values
+   * @private
+   */
+  c() {
+    const output = this.o;
+    const length = output.length;
+    if (length) this.v.set(output.splice(0), this.g(length));
+  }
+
+  /**
+   * grow the buffer
+   * @private
+   * @param {number} byteLength
+   * @returns {number}
+   */
+  g(byteLength) {
+    const { buffer, byteOffset } = this.v;
+    const length = this.l;
+    this.l += byteLength;
+    byteLength += byteOffset + length;
+    //@ts-ignore
+    if (buffer.byteLength < byteLength) buffer.grow(byteLength);
+    return length;
+  }
+}

--- a/types/direct/array.d.ts
+++ b/types/direct/array.d.ts
@@ -1,0 +1,33 @@
+export default class BufferedArray {
+    /**
+     * @param {BufferedArray} self
+     * @param {Uint8Array} value
+     */
+    static push(self: BufferedArray, value: Uint8Array): void;
+    /**
+     * @param {SharedArrayBuffer} buffer
+     * @param {number} offset
+     */
+    constructor(buffer: SharedArrayBuffer, offset: number);
+    /** @private length */
+    private l;
+    /** @private view */
+    private v;
+    /** @private output */
+    private o;
+    /** @type {typeof Array.prototype.push} */
+    push: typeof Array.prototype.push;
+    get length(): number;
+    /**
+     * commit values
+     * @private
+     */
+    private c;
+    /**
+     * grow the buffer
+     * @private
+     * @param {number} byteLength
+     * @returns {number}
+     */
+    private g;
+}


### PR DESCRIPTION
So this is actually refreshing as it uses just a plain `number[]` array to fill up the encoding *but*, when views are met in the process (that is *strings* or *array buffers* carried via *views*) there is no double unrolling of the values, the *buffer* gets assigned out of the box as it is and at the right place.

This basically makes the encoding a *one-off* when no strings or buffers are encountered but an *incremental grow* when these happens, splitting in chunks the *SharedArrayBuffer* filling.

There is only one last tiny trick I'd like to explore, which is not passing through the split when strings are small, but that might be it after that.