### PR TITLE
Added the possibility to memoize proxies in an optimistic way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 dist/
 node_modules/
 coincident-*
+test/index-timeout.js

--- a/types/local.d.ts
+++ b/types/local.d.ts
@@ -1,4 +1,4 @@
-declare function _default({ reflect, transform, remote, module, buffer, }?: LocalOptions): {
+declare function _default({ reflect, transform, remote, module, buffer, timeout, }?: LocalOptions): {
     /**
      * Alows local references to be passed directly to the remote receiver,
      * either as copy or serliazied values (it depends on the implementation).
@@ -48,4 +48,8 @@ export type LocalOptions = {
      * Optionally allows direct buffer serialization breaking JSON compatibility.
      */
     buffer?: boolean;
+    /**
+     * Optionally allows remote values to be cached when possible for a `timeout` milliseconds value. `-1` means no timeout.
+     */
+    timeout?: number;
 };

--- a/types/remote.d.ts
+++ b/types/remote.d.ts
@@ -1,4 +1,4 @@
-declare function _default({ reflect, transform, released, buffer, }?: RemoteOptions): {
+declare function _default({ reflect, transform, released, buffer, timeout, }?: RemoteOptions): {
     /**
      * The local global proxy reference.
      * @type {unknown}
@@ -71,4 +71,8 @@ export type RemoteOptions = {
      * Optionally allows direct buffer deserialization breaking JSON compatibility.
      */
     buffer?: boolean;
+    /**
+     * Optionally allows remote values to be cached when possible for a `timeout` milliseconds value. `-1` means no timeout.
+     */
+    timeout?: number;
 };


### PR DESCRIPTION
This variant adds little code, not much extra logic when `timeout` option is not used, but it can drastically reduce the amount of roundtrips needed to retrieve (especially repeatedly) same values per proxy, improving performance specially when libraries that access all the time same properties are part of the worker/remote logic.

### To be considered

  * the approach is *optimistic*: there is no guarantee that if a value is cached is reflected with the same value elsewhere
  * mostly keys and `get` traps benefit from it, all other traps must invalidate memoized keys (delete, defineProperty, etc)
  * the logic is slower on both local and remote for `get` trap because it cannot cache properties with accessors **but** the outcome is less roundtrip, serialization and whatnot ... it might be a win-win or useless, time will tell
  * `timeout` option is used to schedule a cleanup of all cached keys and related values per each proxy. If `-1` (default) there won't be any cache used at all, if `0` (suggested) or greater, it dictates for how long properties should be cached.

Please note that the cache is a forever growing list of proxies and keys to drop so that passing `Infinity`, as example, is a very bad idea, but in general the logic should just work nicely within the current "*tick*" and all drops and sync delayed after.

Performance when no `timeout` is used should not be affected much, it's just an `if` condition with no extra or different logic attached (from the previous version).

