### PR TITLE
Workaround for broken Proxies

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ const array = [1, 2, 3];
 const bootstrap = timeout => ({
   there: remote({
     timeout,
+    noSymbol: globalThis.timeout === 1,
     reflect: (...args) => here.reflect(...args),
     transform: value => value === array ? there.direct(array) : value,
   }),

--- a/types/remote.d.ts
+++ b/types/remote.d.ts
@@ -1,4 +1,4 @@
-declare function _default({ reflect, transform, released, buffer, timeout, }?: RemoteOptions): {
+declare function _default({ reflect, transform, released, buffer, timeout, noSymbol, }?: RemoteOptions): {
     /**
      * The local global proxy reference.
      * @type {unknown}
@@ -75,4 +75,8 @@ export type RemoteOptions = {
      * Optionally allows remote values to be cached when possible for a `timeout` milliseconds value. `-1` means no timeout.
      */
     timeout?: number;
+    /**
+     * Optionally avoid using a symbol to track known proxies.
+     */
+    noSymbol?: boolean;
 };


### PR DESCRIPTION
There are cases like current *MicroPython* where symbols check (or access if not `Symbol.iterator`) will break the runtime out of the box: https://github.com/micropython/micropython/pull/17604

This workaround allows consumers to disable the internal usage of symbols to quickly check via `in` operator if a particular reference is a known proxy or not.

In theory performance should be good enough except we have constant *O(1)* per each created proxy or check, as opposite of a simple equality check between two strings/symbols references.

This code should actually go sooner than later as it doesn't add any value to this project but at least in particular runtimes or cases where the Proxy implementation would not consider JS symbols it gets a chance to work reasonably fast regardless.