### PR TITLE
Added Web types - currently ImageData

### DIFF
--- a/src/direct/decoder.js
+++ b/src/direct/decoder.js
@@ -29,8 +29,12 @@ import {
   SET,
   VIEW,
 
+  IMAGE_DATA,
+
   RECURSION
 } from './types.js';
+
+import { ImageData } from './web.js';
 
 import { decoder as textDecoder } from '../utils/text.js';
 import { defineProperty } from '../utils/index.js';
@@ -140,6 +144,17 @@ const deflate = (input, cache) => {
       const error = new Class(message);
       return $(cache, i - 1, defineProperty(error, 'stack', { value: stack }));
     }
+    /* c8 ignore start */
+    case IMAGE_DATA: {
+      const data = deflate(input, cache);
+      const width = deflate(input, cache);
+      const height = deflate(input, cache);
+      const colorSpace = deflate(input, cache);
+      const pixelFormat = deflate(input, cache);
+      const settings = { colorSpace, pixelFormat };
+      return $(cache, i - 1, new ImageData(data, width, height, settings));
+    }
+    /* c8 ignore stop */
     case REGEXP: {
       const source = deflate(input, cache);
       const flags = deflate(input, cache);

--- a/src/direct/encoder.js
+++ b/src/direct/encoder.js
@@ -30,8 +30,12 @@ import {
   SET,
   VIEW,
 
+  IMAGE_DATA,
+
   RECURSION,
 } from './types.js';
+
+import { ImageData } from './web.js';
 
 import Stack from './array.js';
 import { isArray, isView, push } from '../utils/index.js';
@@ -146,6 +150,17 @@ const inflate = (input, output, cache) => {
           inflate(input.message, output, cache);
           inflate(input.stack, output, cache);
           break;
+        /* c8 ignore start */
+        case input instanceof ImageData:
+          output.push(IMAGE_DATA);
+          inflate(input.data, output, cache);
+          inflate(input.width, output, cache);
+          inflate(input.height, output, cache);
+          inflate(input.colorSpace, output, cache);
+          //@ts-ignore
+          inflate(input.pixelFormat, output, cache);
+          break;
+        /* c8 ignore stop */
         case input instanceof RegExp:
           output.push(REGEXP);
           inflate(input.source, output, cache);

--- a/src/direct/types.js
+++ b/src/direct/types.js
@@ -31,4 +31,6 @@ export const REGEXP = i++;
 export const SET = i++;
 export const VIEW = i++;
 
+export const IMAGE_DATA = i++;
+
 export const RECURSION = i++;

--- a/src/direct/web.js
+++ b/src/direct/web.js
@@ -1,0 +1,3 @@
+class Never {}
+
+export const ImageData = globalThis.ImageData || /** @type {typeof ImageData} */(Never);

--- a/src/local.js
+++ b/src/local.js
@@ -38,6 +38,8 @@ import {
   REMOTE_FUNCTION,
 } from './types.js';
 
+import { ImageData } from './direct/web.js';
+
 import {
   fromSymbol,
   toSymbol,
@@ -171,7 +173,7 @@ export default ({
         if (value === null) break;
         if (value === globalThis) return globalTarget;
         const $ = transform(value);
-        return (hasDirect && direct.has($)) ?
+        return ((hasDirect && direct.has($)) || $ instanceof ImageData) ?
           tv(DIRECT, $) : (
           isView($) ?
             tv(VIEW, toView($, buffer)) : (

--- a/test/patch.js
+++ b/test/patch.js
@@ -1,0 +1,9 @@
+globalThis.ImageData ??= class ImageData {
+  constructor(data, width, height, { colorSpace, pixelFormat }) {
+    this.data = data;
+    this.width = width;
+    this.height = height;
+    this.colorSpace = colorSpace;
+    this.pixelFormat = pixelFormat;
+  }
+};

--- a/test/worker.js
+++ b/test/worker.js
@@ -29,6 +29,7 @@ testObject.a = 456;
 console.log(global.testArray, global.testObject);
 
 console.log(new global.Date());
+console.log('ImageData', new global.ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1, { colorSpace: 'srgb' }));
 
 const { log } = global.console;
 const obj = { a: 123 };

--- a/types/direct/types.d.ts
+++ b/types/direct/types.d.ts
@@ -22,4 +22,5 @@ export const OBJECT: number;
 export const REGEXP: number;
 export const SET: number;
 export const VIEW: number;
+export const IMAGE_DATA: number;
 export const RECURSION: number;

--- a/types/direct/web.d.ts
+++ b/types/direct/web.d.ts
@@ -1,0 +1,1 @@
+export const ImageData: any;


### PR DESCRIPTION
There are extra types that don't travel properly from the main to the worker (but travels well vice-versa as structured-clone compatible).

ImageData is one of these types that also, having a *read-only* `data` field, might mislead or break users' intents with remote code creating these references via `context.createImageData(...)` out of a local *canvas* reference.